### PR TITLE
ExecutionHistoryRecord type for downstream typing

### DIFF
--- a/src/contract.ts
+++ b/src/contract.ts
@@ -38,9 +38,25 @@ export interface MsgInfo {
   funds: Coin[];
 }
 
+export type ExecutionHistoryRecord = {
+  request: {
+    env: Env,
+    info: MsgInfo,
+  } & (
+    | {
+        instantiateMsg: any;
+      }
+    | {
+        executeMsg: any;
+      }
+  );
+  response: any;
+  state: IIterStorage;
+}
+
 export class CWContractInstance {
   public vm: VMInstance;
-  public executionHistory: any[] = [];
+  public executionHistory: ExecutionHistoryRecord[] = [];
 
   private _chain: () => CWChain;
 


### PR DESCRIPTION
Simply introduces a new type `ExecutionHistoryRecord` which makes using it in downstream packages/projects more descriptive