### PR TITLE
Query Time Travel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terran-one/cw-simulate",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Mock blockchain environment for simulating CosmWasm interactions",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/modules/wasm.spec.ts
+++ b/src/modules/wasm.spec.ts
@@ -536,11 +536,13 @@ describe('Query', () => {
       traces,
     );
     
-    expect(app.wasm.query(testContract.address, queryMsg).val).toMatchObject({
-      buffer: ['M1', 'M2', 'M3', 'M4'],
-    });
     expect(app.wasm.queryTrace(traces[0], queryMsg).val).toMatchObject({
       buffer: ['M1', 'M2', 'M3'],
+    });
+    // IMPORTANT: `queryTrace` temporarily alters the backend a VM uses
+    // so we test here that it resets it
+    expect(app.wasm.query(testContract.address, queryMsg).val).toMatchObject({
+      buffer: ['M1', 'M2', 'M3', 'M4'],
     });
   });
 });

--- a/src/modules/wasm.spec.ts
+++ b/src/modules/wasm.spec.ts
@@ -509,4 +509,38 @@ describe('Query', () => {
       admin: null,
     });
   });
+  
+  it('time travel', async () => {
+    const queryMsg = {
+      get_buffer: {},
+    };
+    
+    const traces: TraceLog[] = [];
+    await testContract.execute(
+      info.sender,
+      exec.run(
+        cmd.msg(exec.push('M1')),
+        cmd.msg(exec.push('M2')),
+        cmd.msg(exec.push('M3')),
+      ),
+      [],
+      traces,
+    );
+    
+    await testContract.execute(
+      info.sender,
+      exec.run(
+        cmd.msg(exec.push('M4')),
+      ),
+      [],
+      traces,
+    );
+    
+    expect(app.wasm.query(testContract.address, queryMsg).val).toMatchObject({
+      buffer: ['M1', 'M2', 'M3', 'M4'],
+    });
+    expect(app.wasm.queryTrace(traces[0], queryMsg).val).toMatchObject({
+      buffer: ['M1', 'M2', 'M3'],
+    });
+  });
 });


### PR DESCRIPTION
Add `wasm.queryTrace(trace: TraceLog, msg: any)` to WASM module for executing `query` on given `trace`'s `storeSnapshot`. Extracts the relevant contract address from the trace as well.