### PR TITLE
Transactional Storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terran-one/cw-simulate",
-  "version": "2.6.2",
+  "version": "2.7.0",
   "description": "Mock blockchain environment for simulating CosmWasm interactions",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/CWSimulateApp.ts
+++ b/src/CWSimulateApp.ts
@@ -4,19 +4,23 @@ import { Err, Result } from 'ts-results';
 import { WasmModule, WasmQuery } from './modules/wasm';
 import { BankModule, BankQuery } from './modules/bank';
 import { AppResponse, Binary } from './types';
+import { Transactional, TransactionalLens } from './store/transactional';
 
 export interface CWSimulateAppOptions {
   chainId: string;
   bech32Prefix: string;
 }
 
+export type ChainData = {
+  height: number;
+  time: number;
+}
+
 export class CWSimulateApp {
   public chainId: string;
   public bech32Prefix: string;
 
-  public store: Map<string, any>;
-  public height: number;
-  public time: number;
+  public store: TransactionalLens<ChainData>;
 
   public wasm: WasmModule;
   public bank: BankModule;
@@ -25,9 +29,10 @@ export class CWSimulateApp {
   constructor(options: CWSimulateAppOptions) {
     this.chainId = options.chainId;
     this.bech32Prefix = options.bech32Prefix;
-    this.store = Map<string, any>();
-    this.height = 1;
-    this.time = 0;
+    this.store = new Transactional().lens<ChainData>().initialize({
+      height: 1,
+      time: 0,
+    });
 
     this.wasm = new WasmModule(this);
     this.bank = new BankModule(this);
@@ -47,6 +52,9 @@ export class CWSimulateApp {
       return Err(`unknown message: ${JSON.stringify(msg)}`);
     }
   }
+  
+  get height() { return this.store.get('height') }
+  get time() { return this.store.get('time') }
 }
 
 export type QueryMessage =

--- a/src/modules/bank.spec.ts
+++ b/src/modules/bank.spec.ts
@@ -1,8 +1,8 @@
-import { Map } from 'immutable';
+import { fromJS } from 'immutable';
 import { cmd, exec, TestContract } from '../../testing/wasm-util';
 import { CWSimulateApp } from '../CWSimulateApp';
 import { fromBinary } from '../util';
-import { BankMessage, BankQuery, ParsedCoin } from './bank';
+import { BankMessage, BankQuery } from './bank';
 
 type WrappedBankMessage = {
   bank: BankMessage;
@@ -27,43 +27,43 @@ describe('BankModule', () => {
     bank.send('alice', 'bob', [{denom: 'foo', amount: '100'}]).unwrap();
 
     // Assert
-    expect(bank.getBalance('alice')).toEqual([new ParsedCoin('foo', BigInt(900))]);
-    expect(bank.getBalance('bob')).toEqual([new ParsedCoin('foo', BigInt(100))]);
-    expect(bank.getBalances()).toEqual(Map([
-      ['alice', [{denom: 'foo', amount: '900'}]],
-      ['bob',   [{denom: 'foo', amount: '100'}]],
-    ]));
+    expect(bank.getBalance('alice')).toEqual([coin('foo', 900)]);
+    expect(bank.getBalance('bob')).toEqual([coin('foo', 100)]);
+    expect(bank.getBalances()).toEqual(fromJS({
+      alice: [coin('foo', 900)],
+      bob:   [coin('foo', 100)],
+    }));
   });
 
   it('handle send failure', () => {
     // Arrange
     const bank = chain.bank;
-    bank.setBalance('alice', [{denom: 'foo', amount: '100'}]);
+    bank.setBalance('alice', [coin('foo', 100)]);
 
     // Act
-    const res = bank.send('alice', 'bob', [{denom: 'foo', amount: '1000'}]);
+    const res = bank.send('alice', 'bob', [coin('foo', 1000)]);
 
     // Assert
     expect(res.err).toBeDefined();
-    expect(bank.getBalances()).toEqual(Map([
-      ['alice', [{denom: 'foo', amount: '100'}]],
-    ]));
-    expect(bank.getBalance('alice')).toEqual([new ParsedCoin('foo', BigInt(100))]);
+    expect(bank.getBalances()).toEqual(fromJS({
+      alice: [coin('foo', 100)],
+    }));
+    expect(bank.getBalance('alice')).toEqual([coin('foo', 100)]);
   });
 
   it('handle burn', () => {
     // Arrange
     const bank = chain.bank;
-    bank.setBalance('alice', [{denom: 'foo', amount: '1000'}]);
+    bank.setBalance('alice', [coin('foo', 1000)]);
 
     // Act
-    bank.burn('alice', [{denom: 'foo', amount: '100'}]);
+    bank.burn('alice', [coin('foo', 100)]);
 
     // Assert
-    expect(bank.getBalance('alice')).toEqual([new ParsedCoin('foo', BigInt(900))]);
-    expect(bank.getBalances()).toEqual(Map([
-      ['alice', [{denom: 'foo', amount: '900'}]],
-    ]));
+    expect(bank.getBalance('alice')).toEqual([coin('foo', 900)]);
+    expect(bank.getBalances()).toEqual(fromJS({
+      alice: [coin('foo', 900)],
+    }));
   });
 
   it('handle burn failure', () => {
@@ -76,16 +76,16 @@ describe('BankModule', () => {
 
     // Assert
     expect(res.err).toBeDefined()
-    expect(bank.getBalance('alice')).toEqual([new ParsedCoin('foo', BigInt(100))]);
-    expect(bank.getBalances()).toEqual(Map([
-      ['alice', [{denom: 'foo', amount: '100'}]],
-    ]));
+    expect(bank.getBalance('alice')).toEqual([coin('foo', 100)]);
+    expect(bank.getBalances()).toEqual(fromJS({
+      alice: [coin('foo', 100)],
+    }));
   });
 
   it('handle msg', () => {
     // Arrange
     const bank = chain.bank;
-    bank.setBalance('alice', [{denom: 'foo', amount: '1000'}]);
+    bank.setBalance('alice', [coin('foo', 1000)]);
 
     // Act
     let msg: WrappedBankMessage = {
@@ -99,10 +99,10 @@ describe('BankModule', () => {
     chain.handleMsg('alice', msg);
 
     // Assert
-    expect(bank.getBalances()).toEqual(Map([
-      ['alice', [{denom: 'foo', amount: '900'}]],
-      ['bob',   [{denom: 'foo', amount: '100'}]],
-    ]));
+    expect(bank.getBalances()).toEqual(fromJS({
+      alice: [coin('foo', 900)],
+      bob:   [coin('foo', 100)],
+    }));
   });
 
   it('contract integration', async () => {
@@ -116,18 +116,18 @@ describe('BankModule', () => {
       cmd.bank({
         send: {
           to_address: 'alice',
-          amount: [{denom: 'foo', amount: '100'}],
+          amount: [coin('foo', 100)],
         },
       }),
       cmd.bank({
         send: {
           to_address: 'bob',
-          amount: [{denom: 'foo', amount: '100'}],
+          amount: [coin('foo', 100)],
         },
       }),
       cmd.bank({
         burn: {
-          amount: [{denom: 'foo', amount: '100'}],
+          amount: [coin('foo', 100)],
         },
       }),
     );
@@ -135,11 +135,11 @@ describe('BankModule', () => {
 
     // Assert
     expect(res.ok).toBeTruthy();
-    expect(bank.getBalances()).toEqual(Map([
-      [contract.address, [{denom: 'foo', amount: '700'}]],
-      ['alice', [{denom: 'foo', amount: '100'}]],
-      ['bob',   [{denom: 'foo', amount: '100'}]],
-    ]));
+    expect(bank.getBalances()).toEqual(fromJS({
+      [contract.address]: [coin('foo', 700)],
+      alice: [coin('foo', 100)],
+      bob:   [coin('foo', 100)],
+    }));
   });
   
   it('querier integration', () => {
@@ -159,28 +159,29 @@ describe('BankModule', () => {
     };
     
     bank.setBalance('alice', [
-      { denom: 'foo', amount: '100' },
-      { denom: 'bar', amount: '200' },
+      coin('foo', 100),
+      coin('bar', 200),
     ]);
     bank.setBalance('bob', [
-      { denom: 'foo', amount: '200' },
-      { denom: 'bar', amount: '200' },
+      coin('foo', 200),
+      coin('bar', 200),
     ]);
     
     let res = chain.querier.handleQuery({ bank: queryBalance });
     expect(res.ok).toBeTruthy();
-    expect(fromBinary(res.val)).toEqual({ amount: { denom: 'foo', amount: '100' }});
+    expect(fromBinary(res.val)).toEqual({ amount: coin('foo', 100)});
     
     res = chain.querier.handleQuery({ bank: queryAllBalances });
     expect(res.ok).toBeTruthy();
     expect(fromBinary(res.val)).toEqual({
       amount: [
-        { denom: 'foo', amount: '200' },
-        { denom: 'bar', amount: '200' },
+        coin('foo', 200),
+        coin('bar', 200),
       ],
     });
   });
-    it('handle delete', () => {
+  
+  it('handle delete', () => {
     // Arrange
     const bank = chain.bank;
     bank.setBalance('alice', [{denom: 'foo', amount: '1000'}]);
@@ -191,8 +192,10 @@ describe('BankModule', () => {
 
     // Assert
     expect(bank.getBalance('alice')).toBeDefined();
-    expect(bank.getBalances()).toEqual(Map([
-      ['alice', [{denom: 'foo', amount: '1000'}]]
-    ]));
+    expect(bank.getBalances()).toEqual(fromJS({
+      alice: [{denom: 'foo', amount: '1000'}],
+    }));
   });
 });
+
+const coin = (denom: string, amount: string | number) => ({ denom, amount: `${amount}` });

--- a/src/store/transactional.ts
+++ b/src/store/transactional.ts
@@ -1,0 +1,101 @@
+import { List, Map } from "immutable";
+import { Ok, Result } from "ts-results";
+
+type Primitive = boolean | number | bigint | string | null | undefined | symbol;
+
+type Prefix<P, T extends any[]> = [P, ...T];
+type First<T extends any[]> = T extends Prefix<infer F, any[]> ? F : never;
+type Shift<T extends any[]> = T extends Prefix<any, infer R> ? R : [];
+
+// god type
+type Lens<T, P extends PropertyKey[]> =
+  P extends Prefix<any, any[]>
+  ? First<P> extends keyof T
+    ? Shift<P> extends Prefix<any, any[]>
+      ? Lens<T[First<P>], Shift<P>>
+      : T[First<P>]
+    : never
+  : T;
+
+type Immutify<T> =
+  T extends Primitive
+  ? T
+  : T extends (infer E)[]
+  ? List<Immutify<E>>
+  : T extends Record<infer K, infer V>
+  ? Map<K, V>
+  : T;
+
+type TxUpdater = (set: TxSetter) => void;
+type TxSetter = (current: Map<unknown, unknown>) => Map<unknown, unknown>;
+type LensSetter<T> = <P extends PropertyKey[]>(...path: P) => ((value: Immutify<Lens<T, P>>) => void);
+
+/** Transactional database underlying multi-module chain storage. */
+export class Transactional {
+  private _data = Map();
+  
+  constructor() {}
+  
+  lens<M extends object>(...path: PropertyKey[]) {
+    return new TransactionalLens<M>(this, path);
+  }
+  
+  tx<R extends Result<any, any>>(cb: (update: TxUpdater) => R): R {
+    let valid = true;
+    const snapshot = this._data;
+    const updater: TxUpdater = setter => {
+      if (!valid) throw new Error('Attempted to set data outside tx');
+      this._data = setter(this._data);
+    };
+    
+    try {
+      const result = cb(updater);
+      if (result.err) {
+        this._data = snapshot;
+      }
+      return result;
+    }
+    catch (ex) {
+      this._data = snapshot;
+      throw ex;
+    }
+    finally {
+      valid = false;
+    }
+  }
+  
+  get data() {
+    return this._data;
+  }
+}
+
+export class TransactionalLens<M extends object> {
+  constructor(public readonly db: Transactional, public readonly prefix: PropertyKey[]) {}
+  
+  initialize(data: M) {
+    this.db.tx(update => {
+      update(curr => curr.setIn([...this.prefix], Map(data)));
+      return Ok(undefined);
+    }).unwrap();
+  }
+  
+  get<P extends PropertyKey[]>(...path: P): Immutify<Lens<M, P>> {
+    return this.db.data.getIn([...this.prefix, ...path]) as any;
+  }
+  
+  tx<R extends Result<any, any>>(cb: (setter: LensSetter<M>) => R): R {
+    return this.db.tx(update => {
+      const setter: LensSetter<M> = <P extends PropertyKey[]>(...path: P) =>
+        (value: Immutify<Lens<M, P>>) => {
+          update(curr => curr.setIn([...this.prefix, ...path], value));
+        }
+      return cb(setter);
+    });
+  }
+  
+  lens<P extends PropertyKey[]>(...path: P): TransactionalLens<Lens<M, P>> {
+    return new TransactionalLens<Lens<M, P>>(this.db, [...this.prefix, ...path]);
+  }
+  
+  get data() { return this.db.data.getIn([...this.prefix]) as Immutify<M> }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,6 +117,8 @@ type CallDebugLog<T extends keyof CosmWasmAPI = keyof CosmWasmAPI> = {
   [K in T]: { fn: K } & CosmWasmAPI[K];
 }>;
 
+export type Snapshot = Immutable.Map<unknown, unknown>;
+
 interface TraceLogCommon {
   type: string;
   contractAddress: string;
@@ -125,7 +127,7 @@ interface TraceLogCommon {
   response: RustResult<ContractResponse>;
   logs: DebugLog[];
   trace?: TraceLog[];
-  storeSnapshot: Immutable.Map<string, any>;
+  storeSnapshot: Snapshot;
   result: Result<AppResponse, string>;
 }
 


### PR DESCRIPTION
Attempt #2 at transactional storage w/ improved typing. This time using `Immutable` types.

Does come with some peculiarities, e.g. some type information is lost when restoring array-like structures. Example: `CodeInfo.wasmCode`, which is internally stored as `Immutable.List<number>` due to conversion with `Immutable.fromJS`

Some changes to bank module API, so will probably need some adjustments in UI