### PR TITLE
Persistence Update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@terran-one/cw-simulate",
-  "version": "2.7.5",
+  "version": "2.8.0-rc.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@terran-one/cw-simulate",
-      "version": "2.7.5",
+      "version": "2.8.0-rc.2",
       "license": "MIT",
       "dependencies": {
         "@cosmjs/amino": "^0.28.13",
         "@cosmjs/crypto": "^0.28.13",
         "@cosmjs/encoding": "^0.28.13",
+        "@kiruse/serde": "^0.6.3",
         "@terran-one/cosmwasm-vm-js": "^0.2.16",
         "immutable": "^4.1.0",
         "lobyte": "^0.0.3",
@@ -3051,6 +3052,14 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "dev": true
     },
+    "node_modules/@kiruse/serde": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@kiruse/serde/-/serde-0.6.3.tgz",
+      "integrity": "sha512-QeiX1E2Jv2lQbcVy5BhW2NoJODi5COKZmUvIDZk9Lwabx8WnLwy3v6RC5bKpVWbK/pOltvK32wYWr3gMrq5Nmg==",
+      "dependencies": {
+        "hash-sum": "^2.0.0"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
@@ -5929,6 +5938,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/hash-sum": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
+      "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg=="
     },
     "node_modules/hash.js": {
       "version": "1.1.7",
@@ -12474,6 +12488,14 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "dev": true
     },
+    "@kiruse/serde": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@kiruse/serde/-/serde-0.6.3.tgz",
+      "integrity": "sha512-QeiX1E2Jv2lQbcVy5BhW2NoJODi5COKZmUvIDZk9Lwabx8WnLwy3v6RC5bKpVWbK/pOltvK32wYWr3gMrq5Nmg==",
+      "requires": {
+        "hash-sum": "^2.0.0"
+      }
+    },
     "@noble/hashes": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
@@ -14812,6 +14834,11 @@
           "dev": true
         }
       }
+    },
+    "hash-sum": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
+      "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg=="
     },
     "hash.js": {
       "version": "1.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terran-one/cw-simulate",
-  "version": "2.8.0-rc.2",
+  "version": "2.8.0-rc.3",
   "description": "Mock blockchain environment for simulating CosmWasm interactions",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terran-one/cw-simulate",
-  "version": "2.7.5",
+  "version": "2.8.0-rc.1",
   "description": "Mock blockchain environment for simulating CosmWasm interactions",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terran-one/cw-simulate",
-  "version": "2.8.0-rc.3",
+  "version": "2.8.0",
   "description": "Mock blockchain environment for simulating CosmWasm interactions",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terran-one/cw-simulate",
-  "version": "2.8.0-rc.1",
+  "version": "2.8.0-rc.2",
   "description": "Mock blockchain environment for simulating CosmWasm interactions",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -39,6 +39,7 @@
     "@cosmjs/amino": "^0.28.13",
     "@cosmjs/crypto": "^0.28.13",
     "@cosmjs/encoding": "^0.28.13",
+    "@kiruse/serde": "^0.6.3",
     "@terran-one/cosmwasm-vm-js": "^0.2.16",
     "immutable": "^4.1.0",
     "lobyte": "^0.0.3",

--- a/src/CWSimulateApp.spec.ts
+++ b/src/CWSimulateApp.spec.ts
@@ -1,0 +1,26 @@
+import { toBase64 } from '@cosmjs/encoding';
+import fs from 'fs';
+import { CWSimulateApp } from './CWSimulateApp';
+
+const bytecode = fs.readFileSync('./testing/cw_simulate_tests-aarch64.wasm');
+
+describe('de/serialize', () => {
+  it('works', async () => {
+    {
+      const ref = new CWSimulateApp({ chainId: 'phoenix-1', bech32Prefix: 'terra1' });
+      ref.wasm.create('alice', bytecode);
+      ref.wasm.create('bob',   bytecode);
+      
+      const clone = CWSimulateApp.deserialize(ref.serialize());
+      expect(clone.chainId).toStrictEqual(ref.chainId);
+      expect(clone.bech32Prefix).toStrictEqual(ref.bech32Prefix);
+      
+      const code1 = clone.wasm.getCodeInfo(1)!;
+      const code2 = clone.wasm.getCodeInfo(2)!;
+      expect(code1.creator).toStrictEqual('alice');
+      expect(code2.creator).toStrictEqual('bob');
+      expect(toBase64(code1.wasmCode)).toStrictEqual(toBase64(ref.wasm.store.getObject('codes', 1, 'wasmCode')));
+      expect(toBase64(code2.wasmCode)).toStrictEqual(toBase64(ref.wasm.store.getObject('codes', 2, 'wasmCode')));
+    }
+  })
+})

--- a/src/CWSimulateApp.ts
+++ b/src/CWSimulateApp.ts
@@ -1,27 +1,9 @@
-import { fromBase64, toBase64 } from '@cosmjs/encoding';
 import { QuerierBase } from '@terran-one/cosmwasm-vm-js';
 import { Err, Ok, Result } from 'ts-results';
 import { WasmModule, WasmQuery } from './modules/wasm';
 import { BankModule, BankQuery } from './modules/bank';
 import { fromImmutable, toImmutable, Transactional, TransactionalLens } from './store/transactional';
 import { AppResponse, Binary } from './types';
-import { getArrayBuffer, isArrayBufferLike, isArrayLike } from './util';
-
-const TYPED_ARRAYS = [
-  null,
-  ArrayBuffer,
-  Int8Array,
-  Uint8Array,
-  Uint8ClampedArray,
-  Int16Array,
-  Uint16Array,
-  Int32Array,
-  Uint32Array,
-  Float32Array,
-  Float64Array,
-  BigInt64Array,
-  BigUint64Array,
-]
 
 export interface CWSimulateAppOptions {
   chainId: string;
@@ -81,30 +63,6 @@ export class CWSimulateApp {
     });
   }
   
-  public serialize() {
-    return JSON.stringify({
-      chainId: this.chainId,
-      bech32Prefix: this.bech32Prefix,
-      data: toPersistable(fromImmutable(this.store.db.data)),
-    });
-  }
-  
-  static deserialize(str: string) {
-    const json = JSON.parse(str);
-    const {
-      bech32Prefix,
-      chainId,
-      data,
-    } = json;
-    
-    const inst = new CWSimulateApp({ chainId, bech32Prefix });
-    inst.store.db.tx(update => {
-      update(() => toImmutable(fromPersistable(data)));
-      return Ok(undefined);
-    });
-    return inst;
-  }
-  
   get height() { return this.store.get('height') }
   get time() { return this.store.get('time') }
 }
@@ -112,13 +70,6 @@ export class CWSimulateApp {
 export type QueryMessage =
   | { bank: BankQuery }
   | { wasm: WasmQuery };
-
-type PersistedTypedArray = {
-  /** Corresponds to TYPED_ARRAYS index */
-  __TYPEDARRAY__: number;
-  /** Base64 encoded binary data */
-  data: string;
-}
 
 export class Querier extends QuerierBase {
   constructor(public readonly app: CWSimulateApp) {
@@ -133,55 +84,5 @@ export class Querier extends QuerierBase {
     } else {
       return Err('Unknown query message');
     }
-  }
-}
-
-/** Alter given data for optimized JSON stringification. Intended for internal use & testing only. */
-export function toPersistable(obj: any): any {
-  if (!obj || typeof obj !== 'object') return obj;
-  if (isArrayLike(obj)) {
-    if (isArrayBufferLike(obj)) {
-      return toPersistedTypedArray(obj);
-    } else {
-      return obj.map(item => toPersistable(item));
-    }
-  } else {
-    return Object.fromEntries(Object.entries(obj).map(([prop, value]) => [prop, toPersistable(value)]));
-  }
-}
-
-/** Restore data from altered persistable representation. Inverse of `toPersistable`. Intended for internal use & testing only. */
-export function fromPersistable(obj: any): any {
-  if (!obj || typeof obj !== 'object') return obj;
-  if ('__TYPEDARRAY__' in obj) {
-    return fromPersistedTypedArray(obj);
-  } else if (isArrayLike(obj)) {
-    return obj.map(item => fromPersistable(item));
-  } else {
-    return Object.fromEntries(Object.entries(obj).map(([prop, value]) => [prop, fromPersistable(value)]));
-  }
-}
-
-function toPersistedTypedArray(obj: ArrayBuffer | ArrayBufferView): PersistedTypedArray {
-  const data = getArrayBuffer(obj)!;
-  const idx = TYPED_ARRAYS.findIndex(constr => !!constr && obj instanceof constr);
-  if (idx === -1) throw new Error('Unknown TypedArray');
-  if (idx ===  0) throw new Error('Contingency Error');
-  return {
-    __TYPEDARRAY__: idx,
-    data: toBase64(new Uint8Array(data)),
-  };
-}
-
-function fromPersistedTypedArray(obj: PersistedTypedArray): ArrayBuffer | ArrayBufferView {
-  const { __TYPEDARRAY__: idx, data } = obj;
-  if (idx < 1 || idx >= TYPED_ARRAYS.length) throw new Error(`Invalid TypedArray type ${idx}`);
-  
-  const bytes = new Uint8Array(fromBase64(data));
-  if (idx === TYPED_ARRAYS.indexOf(ArrayBuffer)) {
-    return bytes.buffer;
-  } else {
-    //@ts-ignore b/c we handle the only two invalid cases above
-    return new TYPED_ARRAYS[idx](bytes.buffer);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
 export * from './CWSimulateApp';
 export * from './types';
 export * from './store';
+
+import { save, load } from './persist';
+export const persist = { save, load };

--- a/src/modules/bank.spec.ts
+++ b/src/modules/bank.spec.ts
@@ -1,4 +1,3 @@
-import { fromJS } from 'immutable';
 import { cmd, exec, TestContract } from '../../testing/wasm-util';
 import { CWSimulateApp } from '../CWSimulateApp';
 import { fromBinary } from '../util';

--- a/src/modules/wasm.ts
+++ b/src/modules/wasm.ts
@@ -202,6 +202,10 @@ export class WasmModule {
     };
   }
 
+  hasVM(contractAddress: string): boolean {
+    return !!this.vms[contractAddress];
+  }
+
   async buildVM(contractAddress: string): Promise<CWSimulateVMInstance> {
     if (!(contractAddress in this.vms)) {
       const contractInfo = this.getContractInfo(contractAddress);

--- a/src/persist.ts
+++ b/src/persist.ts
@@ -1,0 +1,82 @@
+import SerdeProtocol, { SERDE } from '@kiruse/serde';
+import { Reference } from '@kiruse/serde/dist/types';
+import { List, Map } from 'immutable';
+import { Ok } from 'ts-results';
+import { CWSimulateApp } from './CWSimulateApp';
+
+export const serde = SerdeProtocol.standard()
+  .derive('immutable-list',
+    (list: List<any>, data) => {
+      return {
+        data: data(list.toArray()),
+        // ownerID is a unique object that should not even appear on
+        // other Immutable data structures. When present, it signifies
+        // that the Immutable should be mutated in-place rather than
+        // creating copies of its data.
+        mutable: !!(list as any).__ownerID,
+      };
+    },
+    ({ data, mutable }, deref) => {
+      const list = List().asMutable();
+      Reference.all(deref, data, values => {
+        for (const value of values) {
+          list.push(value);
+        }
+        !mutable && list.asImmutable();
+      });
+      return list;
+    },
+  )
+  .derive('immutable-map',
+    (map: Map<any, any>, data) => {
+      return {
+        data: data(map.toObject()),
+        // same as with List above
+        mutable: !!(map as any).__ownerID,
+      };
+    },
+    ({ data, mutable }, deref) => {
+      const map = Map().asMutable();
+      const keys = Object.keys(data);
+      Reference.all(deref, keys.map(k => data[k]), values => {
+        values.forEach((value, i) => {
+          const key = keys[i];
+          map.set(key, value);
+        });
+        !mutable && map.asImmutable();
+      });
+      return map;
+    },
+  )
+  .derive('cw-simulate-app',
+    (app: CWSimulateApp) => ({
+      chainId: app.chainId,
+      bech32Prefix: app.bech32Prefix,
+      store: app.store.db.data,
+    }),
+    ({ chainId, bech32Prefix, store }, deref): CWSimulateApp => {
+      const app = new CWSimulateApp({
+        chainId,
+        bech32Prefix,
+      });
+      Reference.all(deref, [store], ([map]) => {
+        app.store.db.tx(update => {
+          update(() => map);
+          return Ok(undefined);
+        });
+      });
+      return app;
+    },
+  )
+
+export const save = (app: CWSimulateApp) => serde.serializeAs('cw-simulate-app', app).compress().buffer;
+export const load = async (bytes: Uint8Array) => {
+  const app = serde.deserializeAs('cw-simulate-app', bytes);
+  const contracts = [...app.wasm.store.get('contracts').keys()];
+  await Promise.all(contracts.map(address => app.wasm.buildVM(address)));
+  return app;
+};
+
+// Inject SERDE
+Map.prototype[SERDE] = 'immutable-map';
+List.prototype[SERDE] = 'immutable-list';

--- a/src/persist.ts
+++ b/src/persist.ts
@@ -17,6 +17,7 @@ export const serde = SerdeProtocol.standard()
       };
     },
     ({ data, mutable }, deref) => {
+      if (!data.length) return List();
       const list = List().asMutable();
       Reference.all(deref, data, values => {
         for (const value of values) {
@@ -38,6 +39,7 @@ export const serde = SerdeProtocol.standard()
     ({ data, mutable }, deref) => {
       const map = Map().asMutable();
       const keys = Object.keys(data);
+      if (!keys.length) return Map();
       Reference.all(deref, keys.map(k => data[k]), values => {
         values.forEach((value, i) => {
           const key = keys[i];

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,14 +4,6 @@ import { Binary, RustResult } from "./types";
 
 export const isArrayLike = (value: any): value is any[] =>
   typeof value === 'object' && typeof value.length === 'number';
-export const isArrayBufferLike = (value: any): value is ArrayBuffer | ArrayBufferView =>
-  value instanceof ArrayBuffer || ArrayBuffer.isView(value);
-export const getArrayBuffer = (obj: any) =>
-  ArrayBuffer.isView(obj)
-    ? obj.buffer
-    : obj instanceof ArrayBuffer
-    ? obj
-    : undefined;
 
 export const toBinary = (value: any): Binary => toBase64(toUtf8(JSON.stringify(value)));
 export const fromBinary = (str: string): unknown => JSON.parse(fromUtf8(fromBase64(str)));

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,7 +2,16 @@ import { fromBase64, fromUtf8, toBase64, toUtf8 } from "@cosmjs/encoding";
 import { Err, Ok, Result } from "ts-results";
 import { Binary, RustResult } from "./types";
 
-export const isArrayLike = (value: any): value is any[] => typeof value === 'object' && typeof value.length === 'number';
+export const isArrayLike = (value: any): value is any[] =>
+  typeof value === 'object' && typeof value.length === 'number';
+export const isArrayBufferLike = (value: any): value is ArrayBuffer | ArrayBufferView =>
+  value instanceof ArrayBuffer || ArrayBuffer.isView(value);
+export const getArrayBuffer = (obj: any) =>
+  ArrayBuffer.isView(obj)
+    ? obj.buffer
+    : obj instanceof ArrayBuffer
+    ? obj
+    : undefined;
 
 export const toBinary = (value: any): Binary => toBase64(toUtf8(JSON.stringify(value)));
 export const fromBinary = (str: string): unknown => JSON.parse(fromUtf8(fromBase64(str)));


### PR DESCRIPTION
Adds the ability to save & restore the entire CWSimulateApp state with a reference-respecting binary format. Using lower level API, can technically de/serialize only parts of the data store relatively easily for further optimization in CWSimulateUI.