### PR TITLE
Cleanup WASM Module & fix rethrow issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@terran-one/cw-simulate",
-  "version": "2.8.0-rc.2",
+  "version": "2.8.1-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@terran-one/cw-simulate",
-      "version": "2.8.0-rc.2",
+      "version": "2.8.1-rc.1",
       "license": "MIT",
       "dependencies": {
         "@cosmjs/amino": "^0.28.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terran-one/cw-simulate",
-  "version": "2.8.1-rc.1",
+  "version": "2.8.1-rc.2",
   "description": "Mock blockchain environment for simulating CosmWasm interactions",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terran-one/cw-simulate",
-  "version": "2.8.1-rc.2",
+  "version": "2.8.1",
   "description": "Mock blockchain environment for simulating CosmWasm interactions",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terran-one/cw-simulate",
-  "version": "2.8.0",
+  "version": "2.8.1-rc.1",
   "description": "Mock blockchain environment for simulating CosmWasm interactions",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/CWSimulateApp.ts
+++ b/src/CWSimulateApp.ts
@@ -1,8 +1,8 @@
 import { QuerierBase } from '@terran-one/cosmwasm-vm-js';
-import { Err, Ok, Result } from 'ts-results';
+import { Err, Result } from 'ts-results';
 import { WasmModule, WasmQuery } from './modules/wasm';
 import { BankModule, BankQuery } from './modules/bank';
-import { fromImmutable, toImmutable, Transactional, TransactionalLens } from './store/transactional';
+import { Transactional, TransactionalLens } from './store/transactional';
 import { AppResponse, Binary } from './types';
 
 export interface CWSimulateAppOptions {

--- a/src/modules/wasm/contract.ts
+++ b/src/modules/wasm/contract.ts
@@ -1,0 +1,148 @@
+import { BasicBackendApi, BasicKVIterStorage, IBackend } from "@terran-one/cosmwasm-vm-js";
+import { Map } from "immutable";
+import { Ok, Result } from "ts-results";
+import { CWSimulateVMInstance } from "../../instrumentation/CWSimulateVMInstance";
+import { Coin, ContractResponse, DebugLog, ReplyMsg, Snapshot } from "../../types";
+import { fromBinary, fromRustResult } from "../../util";
+import type { WasmModule } from "./module";
+
+/** An interface to interact with CW SCs */
+export default class Contract {
+  private _vm: CWSimulateVMInstance | undefined;
+  
+  constructor(private _wasm: WasmModule, public readonly address: string) {}
+  
+  async init() {
+    if (!this._vm) {
+      const { _wasm: wasm, address } = this;
+      const contractInfo = wasm.getContractInfo(address);
+      if (!contractInfo)
+        throw new Error(`contract ${address} not found`);
+
+      const { codeId } = contractInfo;
+      const codeInfo = wasm.getCodeInfo(codeId);
+      if (!codeInfo)
+        throw new Error(`code ${codeId} not found`);
+
+      const { wasmCode } = codeInfo;
+      const contractState = this.getStorage();
+
+      let storage = new BasicKVIterStorage();
+      storage.dict = contractState;
+
+      let backend: IBackend = {
+        backend_api: new BasicBackendApi(wasm.chain.bech32Prefix),
+        storage,
+        querier: wasm.chain.querier,
+      };
+
+      const logs: DebugLog[] = [];
+      const vm = new CWSimulateVMInstance(logs, backend);
+      await vm.build(wasmCode);
+      this._vm = vm;
+    }
+    return this;
+  }
+  
+  instantiate(
+    sender: string,
+    funds: Coin[],
+    instantiateMsg: any,
+    logs: DebugLog[]
+  ): Result<ContractResponse, string> {
+    if (!this._vm) throw new Error(`No VM for contract ${this.address}`);
+    const vm = this._vm;
+    const env = this.getExecutionEnv();
+    const info = { sender, funds };
+
+    const res = fromRustResult<ContractResponse>(vm.instantiate(env, info, instantiateMsg).json);
+
+    this.setStorage((vm.backend.storage as BasicKVIterStorage).dict);
+
+    logs.push(...vm.logs);
+
+    return res;
+  }
+  
+  execute(
+    sender: string,
+    funds: Coin[],
+    executeMsg: any,
+    logs: DebugLog[],
+  ): Result<ContractResponse, string>
+  {
+    const vm = this._vm;
+    if (!vm) throw new Error(`No VM for contract ${this.address}`);
+    vm.resetDebugInfo();
+
+    const env = this.getExecutionEnv();
+    const info = { sender, funds };
+
+    const res = fromRustResult<ContractResponse>(vm.execute(env, info, executeMsg).json);
+
+    this.setStorage((vm.backend.storage as BasicKVIterStorage).dict);
+
+    logs.push(...vm.logs);
+
+    return res;
+  }
+  
+  reply(
+    replyMsg: ReplyMsg,
+    logs: DebugLog[],
+  ): Result<ContractResponse, string> {
+    if (!this._vm) throw new NoVMError(this.address);
+    const vm = this._vm;
+    const res = fromRustResult<ContractResponse>(vm.reply(this.getExecutionEnv(), replyMsg).json);
+
+    this.setStorage((vm.backend.storage as BasicKVIterStorage).dict);
+
+    logs.push(...vm.logs);
+
+    return res;
+  }
+  
+  query(queryMsg: any, store?: Map<string, string>): Result<any, string> {
+    if (!this._vm) throw new NoVMError(this.address);
+    const vm = this._vm;
+    
+    // time travel
+    const currBackend = vm.backend;
+    const storage = new BasicKVIterStorage(this.getStorage(store));
+    vm.backend = {
+      ...vm.backend,
+      storage,
+    };
+    
+    try {
+      let env = this.getExecutionEnv();
+      return fromRustResult<string>(vm.query(env, queryMsg).json)
+        .andThen(v => Ok(fromBinary(v)));
+    }
+    // reset time travel
+    finally {
+      vm.backend = currBackend;
+    }
+  }
+  
+  setStorage(value: Map<string, string>) {
+    this._wasm.setContractStorage(this.address, value);
+  }
+  
+  getStorage(storage?: Snapshot): Map<string, string> {
+    return this._wasm.getContractStorage(this.address, storage);
+  }
+  
+  getExecutionEnv() {
+    return this._wasm.getExecutionEnv(this.address);
+  }
+  
+  get vm() { return this._vm }
+  get valid() { return !!this._vm }
+}
+
+class NoVMError extends Error {
+  constructor(contractAddress: string) {
+    super(`No VM for contract ${contractAddress}`);
+  }
+}

--- a/src/modules/wasm/contract.ts
+++ b/src/modules/wasm/contract.ts
@@ -50,7 +50,7 @@ export default class Contract {
     instantiateMsg: any,
     logs: DebugLog[]
   ): Result<ContractResponse, string> {
-    if (!this._vm) throw new Error(`No VM for contract ${this.address}`);
+    if (!this._vm) throw new NoVMError(this.address);
     const vm = this._vm;
     const env = this.getExecutionEnv();
     const info = { sender, funds };
@@ -72,7 +72,7 @@ export default class Contract {
   ): Result<ContractResponse, string>
   {
     const vm = this._vm;
-    if (!vm) throw new Error(`No VM for contract ${this.address}`);
+    if (!vm) throw new NoVMError(this.address);
     vm.resetDebugInfo();
 
     const env = this.getExecutionEnv();

--- a/src/modules/wasm/index.ts
+++ b/src/modules/wasm/index.ts
@@ -1,0 +1,1 @@
+export * from './module';

--- a/src/modules/wasm/wasm-util.ts
+++ b/src/modules/wasm/wasm-util.ts
@@ -1,0 +1,72 @@
+import { Sha256 } from "@cosmjs/crypto";
+import { AppResponse, ContractResponse, Event } from "../../types";
+
+function numberToBigEndianUint64(n: number): Uint8Array {
+  const buffer = new ArrayBuffer(8);
+  const view = new DataView(buffer);
+  view.setUint32(0, n, false);
+  view.setUint32(4, 0, false);
+  return new Uint8Array(buffer);
+}
+
+export function buildContractAddress(codeId: number, instanceId: number): Uint8Array {
+  let contractId = new Uint8Array([
+    ...numberToBigEndianUint64(codeId),
+    ...numberToBigEndianUint64(instanceId),
+  ]);
+
+  // append module name
+  let mKey = new Uint8Array([
+    ...Uint8Array.from(Buffer.from('wasm', 'utf-8')),
+    0,
+  ]);
+  let payload = new Uint8Array([...mKey, ...contractId]);
+
+  let hasher = new Sha256();
+  hasher.update(Buffer.from('module', 'utf-8'));
+  let th = hasher.digest();
+  hasher = new Sha256(th);
+  hasher.update(payload);
+  let hash = hasher.digest();
+  return hash.slice(0, 20);
+}
+
+export function buildAppResponse(
+  contract: string,
+  customEvent: Event,
+  response: ContractResponse,
+): AppResponse {
+  const appEvents: Event[] = [];
+  // add custom event
+  appEvents.push(customEvent);
+
+  // add contract attributes under `wasm` event type
+  if (response.attributes.length > 0) {
+    appEvents.push({
+      type: 'wasm',
+      attributes: [
+        {
+          key: '_contract_addr',
+          value: contract,
+        },
+        ...response.attributes,
+      ],
+    });
+  }
+
+  // add events and prefix with `wasm-`
+  for (const event of response.events) {
+    appEvents.push({
+      type: `wasm-${event.type}`,
+      attributes: [
+        { key: '_contract_addr', value: contract },
+        ...event.attributes,
+      ],
+    });
+  }
+
+  return {
+    events: appEvents,
+    data: response.data,
+  };
+}

--- a/src/persist.ts
+++ b/src/persist.ts
@@ -75,7 +75,7 @@ export const save = (app: CWSimulateApp) => serde.serializeAs('cw-simulate-app',
 export const load = async (bytes: Uint8Array) => {
   const app = serde.deserializeAs('cw-simulate-app', bytes);
   const contracts = [...app.wasm.store.get('contracts').keys()];
-  await Promise.all(contracts.map(address => app.wasm.buildVM(address)));
+  await Promise.all(contracts.map(address => app.wasm.getContract(address).init()));
   return app;
 };
 

--- a/src/store/transactional.ts
+++ b/src/store/transactional.ts
@@ -1,6 +1,6 @@
 import { isCollection, isList, isMap, List, Map } from "immutable";
-import { Ok, Result } from "ts-results";
-import { isArrayLike } from "../util";
+import { Err, Ok, Result } from "ts-results";
+import { fromRustResult, isArrayLike, isRustResult, isTSResult } from "../util";
 
 // NEVER_IMMUTIFY is a string because that's easily serializable with different algorithms - symbols are not
 export type NeverImmutify = typeof NEVER_IMMUTIFY;
@@ -66,7 +66,7 @@ export class Transactional {
         })
         .catch(reason => {
           this._data = snapshot;
-          return reason;
+          throw reason;
         })
       }
       else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,7 +126,7 @@ interface TraceLogCommon {
   contractAddress: string;
   env: ExecuteEnv;
   msg: any;
-  response: RustResult<ContractResponse>;
+  response: Result<ContractResponse, string>;
   logs: DebugLog[];
   trace?: TraceLog[];
   storeSnapshot: Snapshot;

--- a/src/util.ts
+++ b/src/util.ts
@@ -26,3 +26,6 @@ export function toRustResult<T>(res: Result<T, string>): RustResult<T> {
     return { error: res.val }
   }
 }
+
+export const isRustResult = <T = unknown>(value: any): value is RustResult<T> => 'ok' in value || 'err' in value;
+export const isTSResult = <T = unknown, E = string>(value: any): value is Result<T, E> => typeof value.ok === 'boolean' && typeof value.err === 'boolean' && 'val' in value;

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,11 +8,13 @@ export const isArrayLike = (value: any): value is any[] =>
 export const toBinary = (value: any): Binary => toBase64(toUtf8(JSON.stringify(value)));
 export const fromBinary = (str: string): unknown => JSON.parse(fromUtf8(fromBase64(str)));
 
-export function fromRustResult<T>(res: RustResult<T>): Result<T, string> {
+export function fromRustResult<T>(res: RustResult<T>): Result<T, string>;
+export function fromRustResult<T>(res: any): Result<T, string>;
+export function fromRustResult<T>(res: any): Result<T, string> {
   if ('ok' in res) {
     return Ok(res.ok);
   }
-  else if ('error' in res) {
+  else if (typeof res.error === 'string') {
     return Err(res.error);
   }
   else throw new Error('Invalid RustResult type');


### PR DESCRIPTION
Clean up WASM module:

* Make methods intended for internal use primarily protected
* Replace all use of `RustResult` with `Result` from `ts-results` for improved type safety
* Refactor out a `Contract` internal class for more robust & structured smart contract instance management & access
* Fix incorrect use of `Promise.prototype.catch` where rejection reason was returned instead of re-thrown causing unexpected types & errors